### PR TITLE
Manage.c :Zombie windows fix

### DIFF
--- a/manage.c
+++ b/manage.c
@@ -428,14 +428,14 @@ uniconify_client(client_t *c)
 	c->state &= ~STATE_ICONIFIED;
 	set_wm_state(c, NormalState);
 
-	c->ignore_unmap++;
 	XDestroyWindow(dpy, c->icon);
 	c->icon = None;
-	c->ignore_unmap++;
+	
 	if (c->icon_xftdraw) {
-		XftDrawDestroy(c->icon_xftdraw);
-		c->icon_xftdraw = None;
+	    XftDrawDestroy(c->icon_xftdraw);
+	    c->icon_xftdraw = None;
 	}
+	
 	XDestroyWindow(dpy, c->icon_label);
 	c->icon_label = None;
 


### PR DESCRIPTION
Fix for some subwindows that not properly unmapping because of ignore_unmap incrementation (e.g: Find dialog in Xfce4-Terminal)